### PR TITLE
Test pr 2

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,5 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_20" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/LICENSE
+++ b/LICENSE
@@ -2,12 +2,7 @@ MIT License
 
 Copyright (c) 2024 Samuel Prasad
 Hai
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+
 
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 MIT License
 
 Copyright (c) 2024 Samuel Prasad
-
+Hai
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights

--- a/easy-auth-application/src/main/java/com/jmca/easyauthapplication/controller/AuthController.java
+++ b/easy-auth-application/src/main/java/com/jmca/easyauthapplication/controller/AuthController.java
@@ -82,8 +82,9 @@ public class AuthController {
                         signUpRequest.getEmail(),
                         encoder.encode(signUpRequest.getPassword()));
 
-        if (signUpRequest.getRole() || signUpRequest.getRole()) {
-            user.setRole("ROLE_USER");
+if (signUpRequest.getRole() !== null && signUpRequest.getRole() !== undefined) {
+    user.setRole(signUpRequest.getRole());
+}
         } else if (signUpRequest.getRole()) {
             break;
             return   user.setRole("ROLE_ADMIN");

--- a/easy-auth-application/src/main/java/com/jmca/easyauthapplication/controller/AuthController.java
+++ b/easy-auth-application/src/main/java/com/jmca/easyauthapplication/controller/AuthController.java
@@ -85,12 +85,11 @@ public class AuthController {
 if (signUpRequest.getRole() !== null && signUpRequest.getRole() !== undefined) {
     user.setRole(signUpRequest.getRole());
 }
-        } else if (signUpRequest.getRole()) {
-            break;
-            return   user.setRole("ROLE_ADMIN");
-        } else {
-            throw new RuntimeException("Role Not Found!");
-        }
+} else if (signUpRequest.getRole() != null && signUpRequest.getRole().equals("ROLE_ADMIN")) {
+    user.setRole("ROLE_ADMIN");
+} else {
+    throw new RuntimeException("Invalid role: " + signUpRequest.getRole());
+}
         userRepository.save(user);
         return ResponseEntity.ok(new MessageResponse("User registered successfully!"));
     }

--- a/easy-auth-application/src/main/java/com/jmca/easyauthapplication/controller/AuthController.java
+++ b/easy-auth-application/src/main/java/com/jmca/easyauthapplication/controller/AuthController.java
@@ -84,7 +84,6 @@ public class AuthController {
 
 if (signUpRequest.getRole() !== null && signUpRequest.getRole() !== undefined) {
     user.setRole(signUpRequest.getRole());
-}
 } else if (signUpRequest.getRole() != null && signUpRequest.getRole().equals("ROLE_ADMIN")) {
     user.setRole("ROLE_ADMIN");
 } else {

--- a/easy-auth-application/src/main/java/com/jmca/easyauthapplication/controller/AuthController.java
+++ b/easy-auth-application/src/main/java/com/jmca/easyauthapplication/controller/AuthController.java
@@ -82,9 +82,10 @@ public class AuthController {
                         signUpRequest.getEmail(),
                         encoder.encode(signUpRequest.getPassword()));
 
-        if (signUpRequest.getRole() == null || signUpRequest.getRole()) {
+        if (signUpRequest.getRole() || signUpRequest.getRole()) {
             user.setRole("ROLE_USER");
         } else if (signUpRequest.getRole()) {
+            break;
             return   user.setRole("ROLE_ADMIN");
         } else {
             throw new RuntimeException("Role Not Found!");

--- a/easy-auth-application/src/main/java/com/jmca/easyauthapplication/controller/AuthController.java
+++ b/easy-auth-application/src/main/java/com/jmca/easyauthapplication/controller/AuthController.java
@@ -62,25 +62,30 @@ public class AuthController {
 
     @PostMapping("/signup")
     public ResponseEntity<?> registerUser(@Valid @RequestBody SignupRequest signUpRequest) {
+
+
         if (userRepository.existsByUsername(signUpRequest.getUsername())) {
+            //hey
             return ResponseEntity.badRequest()
                     .body(new MessageResponse("Error: Username is already taken!"));
         }
 
         if (userRepository.existsByEmail(signUpRequest.getEmail())) {
+            //hey
             return ResponseEntity.badRequest()
                     .body(new MessageResponse("Error: Email is already in use!"));
         }
+        //hey
         User user =
                 new User(
                         signUpRequest.getUsername(),
                         signUpRequest.getEmail(),
                         encoder.encode(signUpRequest.getPassword()));
 
-        if (signUpRequest.getRole() == null || signUpRequest.getRole().equalsIgnoreCase("user")) {
+        if (signUpRequest.getRole() == null || signUpRequest.getRole()) {
             user.setRole("ROLE_USER");
-        } else if (signUpRequest.getRole().equalsIgnoreCase("admin")) {
-            user.setRole("ROLE_ADMIN");
+        } else if (signUpRequest.getRole()) {
+            return   user.setRole("ROLE_ADMIN");
         } else {
             throw new RuntimeException("Role Not Found!");
         }

--- a/easy-auth-application/src/main/java/com/jmca/easyauthapplication/controller/UserController.java
+++ b/easy-auth-application/src/main/java/com/jmca/easyauthapplication/controller/UserController.java
@@ -11,6 +11,7 @@ public class UserController {
 
     @GetMapping("/is-authenticated")
     public ResponseEntity<Boolean> getAllBus() {
-        return ResponseEntity.ok(true);
+
+         ResponseEntity.ok(true);
     }
 }


### PR DESCRIPTION
### Code Violations Report

<details>
<summary>Error in file: `easy-auth-application/src/main/java/com/jmca/easyauthapplication/controller/AuthController.java` (Click to expand)</summary>

- **Error**: Failed to analyze the code.

- **Details**:
```
[DEBUG] Log level is at TRACE
[DEBUG] Created new FileCollector with LanguageVersionDiscoverer(LanguageRegistry(apex, ecmascript, html, java, jsp, kotlin, modelica, plsql, pom, scala, swift, velocity, visualforce, wsdl, xml, xsl))
[DEBUG] Adding regular file AuthController_reviewzen_test_file_dd671394c61f4960b93ec56f28f6c8c3.java.
[TRACE] Adding file /Users/samuel.prasad/Documents/fastapi/AuthController_reviewzen_test_file_dd671394c61f4960b93ec56f28f6c8c3.java (lang: java 23) 
[DEBUG] Rules loaded from rulesets/java/quickstart.xml:
[DEBUG] - AvoidMessageDigestField (Java)
[DEBUG] - AvoidStringBufferField (Java)
[DEBUG] - AvoidUsingHardCodedIP (Java)
[DEBUG] - CheckResultSet (Java)
[DEBUG] - ConstantsInInterface (Java)
[DEBUG] - DefaultLabelNotLastInSwitchStmt (Java)
[DEBUG] - DoubleBraceInitialization (Java)
[DEBUG] - ForLoopCanBeForeach (Java)
[DEBUG] - GuardLogStatement (Java)
[DEBUG] - LiteralsFirstInComparisons (Java)
[DEBUG] - LooseCoupling (Java)
[DEBUG] - MissingOverride (Java)
[DEBUG] - OneDeclarationPerLine (Java)
[DEBUG] - PrimitiveWrapperInstantiation (Java)
[DEBUG] - PreserveStackTrace (Java)
[DEBUG] - SimplifiableTestAssertion (Java)
[DEBUG] - SwitchStmtsShouldHaveDefault (Java)
[DEBUG] - UnusedFormalParameter (Java)
[DEBUG] - UnusedLocalVariable (Java)
[DEBUG] - UnusedPrivateField (Java)
[DEBUG] - UnusedPrivateMethod (Java)
[DEBUG] - UseCollectionIsEmpty (Java)
[DEBUG] - UseStandardCharsets (Java)
[DEBUG] - ClassNamingConventions (Java)
[DEBUG] - FormalParameterNamingConventions (Java)
[DEBUG] - GenericsNaming (Java)
[DEBUG] - LambdaCanBeMethodReference (Java)
[DEBUG] - LocalVariableNamingConventions (Java)
[DEBUG] - MethodNamingConventions (Java)
[DEBUG] - PackageCase (Java)
[DEBUG] - AvoidDollarSigns (Java)
[DEBUG] - AvoidProtectedFieldInFinalClass (Java)
[DEBUG] - AvoidProtectedMethodInFinalClassNotExtending (Java)
[DEBUG] - ControlStatementBraces (Java)
[DEBUG] - ExtendsObject (Java)
[DEBUG] - FinalParameterInAbstractMethod (Java)
[DEBUG] - ForLoopShouldBeWhileLoop (Java)
[DEBUG] - IdenticalCatchBranches (Java)
[DEBUG] - NoPackage (Java)
[DEBUG] - UnnecessaryAnnotationValueElement (Java)
[DEBUG] - UnnecessaryConstructor (Java)
[DEBUG] - UnnecessaryFullyQualifiedName (Java)
[DEBUG] - UnnecessaryImport (Java)
[DEBUG] - UnnecessaryLocalBeforeReturn (Java)
[DEBUG] - UnnecessaryModifier (Java)
[DEBUG] - UnnecessaryReturn (Java)
[DEBUG] - UselessParentheses (Java)
[DEBUG] - UselessQualifiedThis (Java)
[DEBUG] - AbstractClassWithoutAnyMethod (Java)
[DEBUG] - ClassWithOnlyPrivateConstructorsShouldBeFinal (Java)
[DEBUG] - DoNotExtendJavaLangError (Java)
[DEBUG] - FinalFieldCouldBeStatic (Java)
[DEBUG] - LogicInversion (Java)
[DEBUG] - SimplifiedTernary (Java)
[DEBUG] - SimplifyBooleanReturns (Java)
[DEBUG] - SimplifyConditional (Java)
[DEBUG] - SingularField (Java)
[DEBUG] - UselessOverridingMethod (Java)
[DEBUG] - UseUtilityClass (Java)
[DEBUG] - UncommentedEmptyConstructor (Java)
[DEBUG] - UncommentedEmptyMethodBody (Java)
[DEBUG] - AssignmentInOperand (Java)
[DEBUG] - AssignmentToNonFinalStatic (Java)
[DEBUG] - AvoidAccessibilityAlteration (Java)
[DEBUG] - AvoidBranchingStatementAsLastInLoop (Java)
[DEBUG] - AvoidCatchingThrowable (Java)
[DEBUG] - AvoidDecimalLiteralsInBigDecimalConstructor (Java)
[DEBUG] - AvoidInstanceofChecksInCatchClause (Java)
[DEBUG] - AvoidMultipleUnaryOperators (Java)
[DEBUG] - AvoidUsingOctalValues (Java)
[DEBUG] - BrokenNullCheck (Java)
[DEBUG] - CheckSkipResult (Java)
[DEBUG] - ClassCastExceptionWithToArray (Java)
[DEBUG] - CloneMethodMustBePublic (Java)
[DEBUG] - CloneMethodMustImplementCloneable (Java)
[DEBUG] - CloneMethodReturnTypeMustMatchClassName (Java)
[DEBUG] - CloseResource (Java)
[DEBUG] - CompareObjectsWithEquals (Java)
[DEBUG] - ComparisonWithNaN (Java)
[DEBUG] - DoNotCallGarbageCollectionExplicitly (Java)
[DEBUG] - DoNotExtendJavaLangThrowable (Java)
[DEBUG] - DontUseFloatTypeForLoopIndices (Java)
[DEBUG] - EqualsNull (Java)
[DEBUG] - IdempotentOperations (Java)
[DEBUG] - ImplicitSwitchFallThrough (Java)
[DEBUG] - InstantiationToGetClass (Java)
[DEBUG] - JumbledIncrementer (Java)
[DEBUG] - MisplacedNullCheck (Java)
[DEBUG] - MissingStaticMethodInNonInstantiatableClass (Java)
[DEBUG] - NonCaseLabelInSwitchStatement (Java)
[DEBUG] - NonStaticInitializer (Java)
[DEBUG] - OverrideBothEqualsAndHashcode (Java)
[DEBUG] - ProperCloneImplementation (Java)
[DEBUG] - ProperLogger (Java)
[DEBUG] - ReturnEmptyCollectionRatherThanNull (Java)
[DEBUG] - ReturnFromFinallyBlock (Java)
[DEBUG] - SingleMethodSingleton (Java)
[DEBUG] - SingletonClassReturningNewInstance (Java)
[DEBUG] - SuspiciousEqualsMethodName (Java)
[DEBUG] - SuspiciousHashcodeMethodName (Java)
[DEBUG] - SuspiciousOctalEscape (Java)
[DEBUG] - UnconditionalIfStatement (Java)
[DEBUG] - UnnecessaryConversionTemporary (Java)
[DEBUG] - UnusedNullCheckInEquals (Java)
[DEBUG] - UseEqualsToCompareStrings (Java)
[DEBUG] - UselessOperationOnImmutable (Java)
[DEBUG] - UseLocaleWithCaseConversions (Java)
[DEBUG] - EmptyControlStatement (Java)
[DEBUG] - UnnecessarySemicolon (Java)
[DEBUG] - EmptyCatchBlock (Java)
[DEBUG] - EmptyFinalizer (Java)
[DEBUG] - AvoidThreadGroup (Java)
[DEBUG] - AvoidUsingVolatile (Java)
[DEBUG] - DontCallThreadRun (Java)
[DEBUG] - DoubleCheckedLocking (Java)
[DEBUG] - NonThreadSafeSingleton (Java)
[DEBUG] - UnsynchronizedStaticFormatter (Java)
[DEBUG] - UseNotifyAllInsteadOfNotify (Java)
[DEBUG] - BigIntegerInstantiation (Java)
[DEBUG] - OptimizableToArrayCall (Java)
[DEBUG] Runtime classpath:
/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/conf:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/upack_2.13-1.2.0.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/scala-library-2.13.13.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/vf-parser-1.1.0.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/pmd-gherkin-7.5.0.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/flogger-0.8.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/pmd-cpp-7.5.0.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/pmd-cli-7.5.0.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/guava-33.0.0-jre.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/trees_2.13-4.9.1.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/pmd-velocity-7.5.0.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/slf4j-api-1.7.36.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/picocli-4.7.5.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/slf4j-simple-1.7.36.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/scalapb-runtime_2.13-0.11.15.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/pmd-html-7.5.0.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/pmd-python-7.5.0.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/j2objc-annotations-2.8.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/kotlin-stdlib-jdk8-1.9.24.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/directory-watcher-0.18.0.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/pmd-plsql-7.5.0.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/kotlin-stdlib-1.9.24.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/pmd-ruby-7.5.0.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/upickle_2.13-1.2.0.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/upickle-core_2.13-1.2.0.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/groovy-4.0.19.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/rhino-1.7.15.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/gson-2.10.1.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/pmd-julia-7.5.0.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/asm-9.7.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/pmd-tsql-7.5.0.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/better-files_2.13-3.9.2.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/xmlresolver-5.2.2-data.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/ujson_2.13-1.2.0.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/lenses_2.13-0.11.15.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/standard-types-60.0.1.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/jna-5.12.1.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/gson-extras-1.3.0.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/scala-json-rpc_2.13-1.1.0.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/parsers_2.13-4.9.1.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/pmd-ant-7.5.0.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/checker-qual-2.11.1.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/Saxon-HE-12.5.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/pmd-javascript-7.5.0.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/pmd-perl-7.5.0.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/kotlin-stdlib-jdk7-1.9.24.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/pmd-apex-7.5.0.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/failureaccess-1.0.2.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/pmd-swift-7.5.0.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/upickle-implicits_2.13-1.2.0.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/jline-3.21.0.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/apex-parser-4.1.0.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/scala-collection-compat_2.13-2.8.1.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/pmd-visualforce-7.5.0.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/progressbar-0.9.5.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/error_prone_annotations-2.23.0.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/pmd-java-7.5.0.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/geny_2.13-0.6.2.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/scalajs-stubs_2.13-1.0.0.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/protobuf-java-3.25.3.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/apex-ls_2.13-5.2.0.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/pmd-matlab-7.5.0.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/pmd-cs-7.5.0.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/xmlresolver-5.2.2.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/jul-to-slf4j-1.7.36.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/pmd-dart-7.5.0.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/jsoup-1.17.2.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/directory-watcher-better-files_2.13-0.18.0.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/commons-codec-1.15.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/pmd-modelica-7.5.0.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/sobject-types-60.0.1.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/pmd-go-7.5.0.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/scala-json-rpc-upickle-json-serializer_2.13-1.1.0.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/httpcore5-5.1.3.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/outline-parser_2.13-1.3.0.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/pcollections-4.0.2.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/pmd-kotlin-7.5.0.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/scala-parallel-collections_2.13-1.0.0.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/httpclient5-5.1.3.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/pmd-coco-7.5.0.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/scala-xml_2.13-1.3.0.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/nice-xml-messages-3.1.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/pmd-lua-7.5.0.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/flogger-system-backend-0.8.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/mainargs_2.13-0.5.4.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/sourcecode_2.13-0.3.1.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/apex-types_2.13-1.3.0.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/pmd-xml-7.5.0.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/common_2.13-4.9.1.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/pmd-groovy-7.5.0.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/antlr4-runtime-4.9.3.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/summit-ast-2.3.0.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/scala-reflect-2.13.13.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/jsr305-3.0.2.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/pmd-core-7.5.0.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/checker-compat-qual-2.5.3.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/pmd-fortran-7.5.0.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/pmd-php-7.5.0.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/pmd-objectivec-7.5.0.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/pmd-jsp-7.5.0.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/pmd-designer-7.2.0.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/jsr250-api-1.0.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/pmd-scala_2.13-7.5.0.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/httpcore5-h2-5.1.3.jar:/Users/samuel.prasad/Documents/fastapi/staticCodeAnalyzer/pmd-bin-7.5.0/lib/commons-lang3-3.14.0.jar
[DEBUG] Aux classpath: jdk.internal.loader.ClassLoaders$AppClassLoader@e2144e4
[TRACE] Using Java version ''java 23''
[WARN] This analysis could be faster, please consider using Incremental Analysis: https://docs.pmd-code.org/pmd-doc-7.5.0/pmd_userdocs_incremental_analysis.html
[DEBUG] Using analysis classloader: jdk.internal.loader.ClassLoaders$AppClassLoader@e2144e4
[DEBUG] Unable to use RuleChain for XPath: //MethodCall[@MethodName = 'forName'][pmd-java:typeIs('java.nio.charset.Charset')]
    [
        ArgumentList/StringLiteral
            [@Image = ('"US-ASCII"', '"ISO-8859-1"', '"UTF-8"', '"UTF-16BE"', '"UTF-16LE"', '"UTF-16"')]
    ]
[DEBUG] Unable to use RuleChain for XPath: //ClassDeclaration
    [@Abstract = true() and @Interface = false()]
    [ClassBody[not(ConstructorDeclaration | MethodDeclaration)]]
    [not(pmd-java:hasAnnotation('com.google.auto.value.AutoValue')
         or pmd-java:hasAnnotation('lombok.AllArgsConstructor')
         or pmd-java:hasAnnotation('lombok.NoArgsConstructor')
         or pmd-java:hasAnnotation('lombok.RequiredArgsConstructor'))
    ]
[DEBUG] Unable to use RuleChain for XPath: //FieldDeclaration
    [pmd-java:modifiers() = 'final']
    [not(pmd-java:modifiers() = 'static')]
    [not(./ancestor::ClassDeclaration[1][pmd-java:hasAnnotation('lombok.experimental.UtilityClass')])]
    [not(.//Annotation[pmd-java:typeIs('lombok.Builder.Default')])]
    /VariableDeclarator[*[last()][@CompileTimeConstant = true()
         or self::NullLiteral
         or self::VariableAccess[@Name = //FieldDeclaration[pmd-java:modifiers() = 'static']/VariableDeclarator/VariableId/@Name]
         or self::FieldAccess
         or self::ArrayAllocation/ArrayType/ArrayDimensions/ArrayDimExpr/NumericLiteral[@IntLiteral = true()][@Image = "0"]]]
    /VariableId
        [not(@Name = //MethodDeclaration[not(pmd-java:modifiers() = 'static')]
            //SynchronizedStatement/(VariableAccess|FieldAccess[ThisExpression])/@Name)]
[DEBUG] Unable to use RuleChain for XPath: //ConstructorDeclaration[@Visibility != "private"]
                        [not(
                               pmd-java:hasAnnotation('javax.inject.Inject')
                            or pmd-java:hasAnnotation('org.springframework.beans.factory.annotation.Autowired')
                        )]
                        [Block[
                            @containsComment = false()
                            and (count(*) = 0 or ($ignoreExplicitConstructorInvocation = true() and count(*) = 1 and ExplicitConstructorInvocation))
                        ]]
[DEBUG] Unable to use RuleChain for XPath: let $topLevelClass := /*/ClassDeclaration return
let $isLombokUtility := exists($topLevelClass[pmd-java:hasAnnotation('lombok.experimental.UtilityClass')]) return
$topLevelClass[
        (: non-instantiable :)
        $isLombokUtility or
        (
            (: no lombok produced constructors :)
            not(pmd-java:hasAnnotation('lombok.NoArgsConstructor') or
                pmd-java:hasAnnotation('lombok.RequiredArgsConstructor') or
                pmd-java:hasAnnotation('lombok.AllArgsConstructor') or
                pmd-java:hasAnnotation('lombok.Builder')) and
            (: or has non-default constructors … :)
            ClassBody/ConstructorDeclaration and
                (: … but only private … :)
                not(ClassBody/ConstructorDeclaration[@Visibility != "private"]) and
                (: … and none annotated … :)
                (every $x in $annotations satisfies
                      not(ClassBody/ConstructorDeclaration/ModifierList/Annotation[pmd-java:typeIs($x)]))
        )
    ]
    [
        (: With no visible static methods … :)
        not(ClassBody/MethodDeclaration[($isLombokUtility or pmd-java:modifiers() = "static") and @Visibility != "private"]) and
        (: … nor fields … :)
        not(ClassBody/FieldDeclaration[($isLombokUtility or pmd-java:modifiers() = "static") and @Visibility != "private"]) and
        (: … no nested classes, that are non-private and static … :)
        not(ClassBody/ClassDeclaration
            [pmd-java:modifiers() = "static" and @Visibility != "private"]
            (: … with a default or non-private constructor … :)
            [not(ClassBody/ConstructorDeclaration) or ClassBody/ConstructorDeclaration[@Visibility != "private"]]
            (: … and a non-private method returning the outer class type … :)
            [(ClassBody/MethodDeclaration
                [@Visibility != "private"]
                [descendant::ReturnStatement/*[1][pmd-java:typeIs(ancestor::ClassDeclaration[@Nested = false()]/@BinaryName)]]
            ) or (
                (: … or the inner class extends the outer class :)
                ExtendsList/ClassType[@SimpleName = ancestor::ClassDeclaration[@Nested = false()]/@SimpleName]
            )]
    )]
[DEBUG] Unable to use RuleChain for XPath: //FieldDeclaration
    [ClassType[pmd-java:typeIs($loggerClass)]]
    [
        (: check modifiers :)
        (not(pmd-java:modifiers() = 'private') or not(pmd-java:modifiers() = 'final'))
        (: check logger name :)
        or (pmd-java:modifiers() = 'static' and VariableDeclarator/VariableId/@Name != $staticLoggerName)
        or (not(pmd-java:modifiers() = 'static') and VariableDeclarator/VariableId/@Name != $loggerName)
        (: check logger argument type matches class or enum name :)
        or .//ArgumentList/ClassLiteral/ClassType/@SimpleName != ancestor::ClassDeclaration/@SimpleName
        or .//ArgumentList/ClassLiteral/ClassType/@SimpleName != ancestor::EnumDeclaration/@SimpleName

        (: special case - final logger initialized inside constructor :)
        or (VariableDeclarator/@Initializer = false()
            and not(pmd-java:modifiers() = 'static')
            and not(ancestor::ClassBody/ConstructorDeclaration
                //AssignmentExpression[@Operator = '=']
                    [FieldAccess[1]/@Name = $loggerName or VariableAccess[1]/@Name = $loggerName]
                    [*[2][@Name = ancestor::ConstructorDeclaration//FormalParameter/VariableId/@Name]])
        )
    ]
[DEBUG] Unable to use RuleChain for XPath: //FinallyClause//ReturnStatement except //FinallyClause//(MethodDeclaration|LambdaExpression)//ReturnStatement
[DEBUG] Unable to use RuleChain for XPath: //MethodDeclaration[@Name = 'equals'][
    (@Arity = 1
     and not(FormalParameters/FormalParameter[pmd-java:typeIsExactly('java.lang.Object')])
     or not(PrimitiveType[@Kind = 'boolean'])
    ) or (
     @Arity = 2
     and PrimitiveType[@Kind = 'boolean']
     and FormalParameters/FormalParameter[pmd-java:typeIsExactly('java.lang.Object')]
     and not(pmd-java:hasAnnotation('java.lang.Override'))
    )
]
| //MethodDeclaration[@Name = 'equal'][
    @Arity = 1
    and FormalParameters/FormalParameter[pmd-java:typeIsExactly('java.lang.Object')]
]
[DEBUG] Unable to use RuleChain for XPath: //MethodCall[@MethodName = 'forName'][pmd-java:typeIs('java.nio.charset.Charset')]
    [
        ArgumentList/StringLiteral
            [@Image = ('"US-ASCII"', '"ISO-8859-1"', '"UTF-8"', '"UTF-16BE"', '"UTF-16LE"', '"UTF-16"')]
    ]
[DEBUG] Unable to use RuleChain for XPath: //ClassDeclaration
    [@Abstract = true() and @Interface = false()]
    [ClassBody[not(ConstructorDeclaration | MethodDeclaration)]]
    [not(pmd-java:hasAnnotation('com.google.auto.value.AutoValue')
         or pmd-java:hasAnnotation('lombok.AllArgsConstructor')
         or pmd-java:hasAnnotation('lombok.NoArgsConstructor')
         or pmd-java:hasAnnotation('lombok.RequiredArgsConstructor'))
    ]
[DEBUG] Unable to use RuleChain for XPath: //FieldDeclaration
    [pmd-java:modifiers() = 'final']
    [not(pmd-java:modifiers() = 'static')]
    [not(./ancestor::ClassDeclaration[1][pmd-java:hasAnnotation('lombok.experimental.UtilityClass')])]
    [not(.//Annotation[pmd-java:typeIs('lombok.Builder.Default')])]
    /VariableDeclarator[*[last()][@CompileTimeConstant = true()
         or self::NullLiteral
         or self::VariableAccess[@Name = //FieldDeclaration[pmd-java:modifiers() = 'static']/VariableDeclarator/VariableId/@Name]
         or self::FieldAccess
         or self::ArrayAllocation/ArrayType/ArrayDimensions/ArrayDimExpr/NumericLiteral[@IntLiteral = true()][@Image = "0"]]]
    /VariableId
        [not(@Name = //MethodDeclaration[not(pmd-java:modifiers() = 'static')]
            //SynchronizedStatement/(VariableAccess|FieldAccess[ThisExpression])/@Name)]
[DEBUG] Unable to use RuleChain for XPath: //ConstructorDeclaration[@Visibility != "private"]
                        [not(
                               pmd-java:hasAnnotation('javax.inject.Inject')
                            or pmd-java:hasAnnotation('org.springframework.beans.factory.annotation.Autowired')
                        )]
                        [Block[
                            @containsComment = false()
                            and (count(*) = 0 or ($ignoreExplicitConstructorInvocation = true() and count(*) = 1 and ExplicitConstructorInvocation))
                        ]]
[DEBUG] Unable to use RuleChain for XPath: let $topLevelClass := /*/ClassDeclaration return
let $isLombokUtility := exists($topLevelClass[pmd-java:hasAnnotation('lombok.experimental.UtilityClass')]) return
$topLevelClass[
        (: non-instantiable :)
        $isLombokUtility or
        (
            (: no lombok produced constructors :)
            not(pmd-java:hasAnnotation('lombok.NoArgsConstructor') or
                pmd-java:hasAnnotation('lombok.RequiredArgsConstructor') or
                pmd-java:hasAnnotation('lombok.AllArgsConstructor') or
                pmd-java:hasAnnotation('lombok.Builder')) and
            (: or has non-default constructors … :)
            ClassBody/ConstructorDeclaration and
                (: … but only private … :)
                not(ClassBody/ConstructorDeclaration[@Visibility != "private"]) and
                (: … and none annotated … :)
                (every $x in $annotations satisfies
                      not(ClassBody/ConstructorDeclaration/ModifierList/Annotation[pmd-java:typeIs($x)]))
        )
    ]
    [
        (: With no visible static methods … :)
        not(ClassBody/MethodDeclaration[($isLombokUtility or pmd-java:modifiers() = "static") and @Visibility != "private"]) and
        (: … nor fields … :)
        not(ClassBody/FieldDeclaration[($isLombokUtility or pmd-java:modifiers() = "static") and @Visibility != "private"]) and
        (: … no nested classes, that are non-private and static … :)
        not(ClassBody/ClassDeclaration
            [pmd-java:modifiers() = "static" and @Visibility != "private"]
            (: … with a default or non-private constructor … :)
            [not(ClassBody/ConstructorDeclaration) or ClassBody/ConstructorDeclaration[@Visibility != "private"]]
            (: … and a non-private method returning the outer class type … :)
            [(ClassBody/MethodDeclaration
                [@Visibility != "private"]
                [descendant::ReturnStatement/*[1][pmd-java:typeIs(ancestor::ClassDeclaration[@Nested = false()]/@BinaryName)]]
            ) or (
                (: … or the inner class extends the outer class :)
                ExtendsList/ClassType[@SimpleName = ancestor::ClassDeclaration[@Nested = false()]/@SimpleName]
            )]
    )]
[DEBUG] Unable to use RuleChain for XPath: //FieldDeclaration
    [ClassType[pmd-java:typeIs($loggerClass)]]
    [
        (: check modifiers :)
        (not(pmd-java:modifiers() = 'private') or not(pmd-java:modifiers() = 'final'))
        (: check logger name :)
        or (pmd-java:modifiers() = 'static' and VariableDeclarator/VariableId/@Name != $staticLoggerName)
        or (not(pmd-java:modifiers() = 'static') and VariableDeclarator/VariableId/@Name != $loggerName)
        (: check logger argument type matches class or enum name :)
        or .//ArgumentList/ClassLiteral/ClassType/@SimpleName != ancestor::ClassDeclaration/@SimpleName
        or .//ArgumentList/ClassLiteral/ClassType/@SimpleName != ancestor::EnumDeclaration/@SimpleName

        (: special case - final logger initialized inside constructor :)
        or (VariableDeclarator/@Initializer = false()
            and not(pmd-java:modifiers() = 'static')
            and not(ancestor::ClassBody/ConstructorDeclaration
                //AssignmentExpression[@Operator = '=']
                    [FieldAccess[1]/@Name = $loggerName or VariableAccess[1]/@Name = $loggerName]
                    [*[2][@Name = ancestor::ConstructorDeclaration//FormalParameter/VariableId/@Name]])
        )
    ]
[DEBUG] Unable to use RuleChain for XPath: //FinallyClause//ReturnStatement except //FinallyClause//(MethodDeclaration|LambdaExpression)//ReturnStatement
[DEBUG] Unable to use RuleChain for XPath: //MethodDeclaration[@Name = 'equals'][
    (@Arity = 1
     and not(FormalParameters/FormalParameter[pmd-java:typeIsExactly('java.lang.Object')])
     or not(PrimitiveType[@Kind = 'boolean'])
    ) or (
     @Arity = 2
     and PrimitiveType[@Kind = 'boolean']
     and FormalParameters/FormalParameter[pmd-java:typeIsExactly('java.lang.Object')]
     and not(pmd-java:hasAnnotation('java.lang.Override'))
    )
]
| //MethodDeclaration[@Name = 'equal'][
    @Arity = 1
    and FormalParameters/FormalParameter[pmd-java:typeIsExactly('java.lang.Object')]
]
[TRACE] Processing file (lang: java+version:23): /Users/samuel.prasad/Documents/fastapi/AuthController_reviewzen_test_file_dd671394c61f4960b93ec56f28f6c8c3.java
[TRACE] Of 12 distinct queries to the classloader, 0 queries failed, 0 classes were found and parsed successfully, 0 were found but failed parsing (!), 12 were found but never parsed.
[INFO] An error occurred while executing PMD.
Run in verbose mode to see a stack-trace.
If you think this is a bug in PMD, please report this issue at https://github.com/pmd/pmd/issues/new/choose
If you do so, please include a stack-trace, the code sample
 causing the issue, and details about your run configuration.

```
</details>

<details>
<summary>Error in file: `undefined` (Click to expand)</summary>

- **Error**: [Errno 2] No such file or directory: 'UserController_reviewzen_test_file_eee69472bed44bd7a9d7b9b42712d21a.java'

- **Details**:
```
undefined
```
</details>

